### PR TITLE
fix(sec): upgrade fastjson to 1.2.83

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spider-flow.version>${project.version}</spider-flow.version>
-		<alibaba.fastjson.version>1.2.58</alibaba.fastjson.version>
+		<alibaba.fastjson.version>1.2.83</alibaba.fastjson.version>
 		<alibaba.druid.version>1.1.16</alibaba.druid.version>
 		<alibaba.transmittable.version>2.11.5</alibaba.transmittable.version>
 		<mybatis.plus.version>3.1.0</mybatis.plus.version>


### PR DESCRIPTION
Upgrade fastjson from 1.2.58 to 1.2.83 for vulnerability fix:
- [MPS-2019-28847](https://www.oscs1024.com/hd/MPS-2019-28847)
- [MPS-2019-28848](https://www.oscs1024.com/hd/MPS-2019-28848)
- [MPS-2020-39708](https://www.oscs1024.com/hd/MPS-2020-39708)
- [CVE-2022-25845](https://www.oscs1024.com/hd/MPS-2022-54205)