### PR TITLE
fix(sec): upgrade com.alibaba:fastjson to 1.2.83

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.spiderflow</groupId>
 	<artifactId>spider-flow</artifactId>


### PR DESCRIPTION
### What happened？
There are 5 security vulnerabilities found in com.alibaba:fastjson 1.2.58
- [CVE-2022-25845](https://www.oscs1024.com/hd/CVE-2022-25845)
- [MPS-2019-28847](https://www.oscs1024.com/hd/MPS-2019-28847)
- [MPS-2019-28848](https://www.oscs1024.com/hd/MPS-2019-28848)
- [MPS-2020-39708](https://www.oscs1024.com/hd/MPS-2020-39708)
- [MPS-2020-40828](https://www.oscs1024.com/hd/MPS-2020-40828)


### What did I do？
Upgrade com.alibaba:fastjson from 1.2.58 to 1.2.83 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS